### PR TITLE
Add OpenAI article framework UI and backend

### DIFF
--- a/finhabits-replit-proxy_v2/README.md
+++ b/finhabits-replit-proxy_v2/README.md
@@ -6,3 +6,16 @@
 - `N8N_TOKEN` = mismo que en n8n (Settings → Variables)
 
 Run → abre la UI → llena y envía.
+
+## Framework SEO + OpenAI
+
+Completa el formulario “Framework Finhabits – Artículo SEO” para generar automáticamente un artículo siguiendo la estructura aprobada. Necesitas definir en Secrets:
+
+- `OPENAI_API_KEY`
+
+El servidor construye el prompt y llama directamente a OpenAI para devolver:
+
+1. El artículo completo listo para revisar/publicar.
+2. El prompt utilizado (visible para copiar/iterar).
+
+El panel superior muestra si el API key y el webhook están configurados.

--- a/finhabits-replit-proxy_v2/index.js
+++ b/finhabits-replit-proxy_v2/index.js
@@ -1,6 +1,7 @@
 
 import express from 'express';
 import fetch from 'node-fetch';
+import OpenAI from 'openai';
 
 const app = express();
 app.use(express.json());
@@ -10,9 +11,15 @@ app.use(express.static('public'));
 const PORT = process.env.PORT || 3000;
 const N8N_WEBHOOK_URL = process.env.N8N_WEBHOOK_URL;
 const N8N_TOKEN = process.env.N8N_TOKEN;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+const openai = OPENAI_API_KEY ? new OpenAI({ apiKey: OPENAI_API_KEY }) : null;
 
 app.get('/env', (req,res)=>{
-  res.json({ N8N_WEBHOOK_URL: N8N_WEBHOOK_URL || null });
+  res.json({
+    N8N_WEBHOOK_URL: N8N_WEBHOOK_URL || null,
+    hasOpenAI: Boolean(OPENAI_API_KEY)
+  });
 });
 
 app.post('/submit', async (req, res) => {
@@ -35,6 +42,194 @@ app.post('/submit', async (req, res) => {
     res.status(r.status).json({ ok: r.ok, status: r.status, data });
   } catch (err) {
     res.status(500).json({ ok:false, error: String(err) });
+  }
+});
+
+function buildArticlePrompt(body){
+  const {
+    topic,
+    primary_kw,
+    secondary_kws = [],
+    seo_title,
+    meta_description,
+    target_url,
+    intent,
+    language,
+    word_count_min,
+    word_count_max,
+    author_name,
+    author_credentials,
+    last_updated,
+    additional_notes,
+    lead_paragraph_seed,
+    outline_sections,
+    serp_strategy,
+    trust_signals,
+    on_page_requirements,
+    ux_modules,
+    internal_linking,
+    style_notes
+  } = body;
+
+  const listFromInput = (value, fallback) => {
+    let arr = [];
+    if (Array.isArray(value)) arr = value;
+    else if (typeof value === 'string') {
+      arr = value
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+    }
+    if (!arr.length) arr = fallback;
+    return arr;
+  };
+
+  const secondaryLine = secondary_kws.length
+    ? secondary_kws.map((kw) => kw.trim()).filter(Boolean).join(', ')
+    : 'None provided';
+
+  const lang = language || 'US English';
+  const intentLine = intent || 'Informational (education-first).';
+  const minWords = word_count_min || 1400;
+  const maxWords = word_count_max || 1900;
+  const authorLine = author_name && author_credentials
+    ? `${author_name}, ${author_credentials}`
+    : (author_name || 'Finhabits Editorial Team');
+  const updatedLine = last_updated || 'September 18, 2025';
+  const notes = additional_notes ? `\n- Additional guardrails: ${additional_notes.trim()}` : '';
+  const leadSeed = lead_paragraph_seed ? lead_paragraph_seed.trim() : '';
+
+  const outlineBlock = listFromInput(outline_sections, [
+    'Intro with outcome-first promise + DefinitionSnippet',
+    `What it is (precise definition with the primary keyword “${primary_kw}” verbatim)`,
+    'Why it matters (benefits, risks, trade-offs)',
+    'Key regulatory or state-by-state requirements (group logically)',
+    'Documents, steps, or process checklist',
+    'Common mistakes and how to avoid delays',
+    'FAQs resolving People-Also-Ask queries',
+    'Glossary (definitions of 6–10 terms)',
+    'CTA + support options'
+  ]);
+
+  const serpBlock = listFromInput(serp_strategy, [
+    `DefinitionSnippet: a 40–55-word lead paragraph that defines the topic using “${primary_kw}” verbatim once.`,
+    'PAA: add 5–7 FAQs with concise, direct answers (40–70 words each). Target comparison and compliance queries.',
+    'Comparison blocks: use tables where relevant (e.g., inclusions vs exclusions, state differences).',
+    'Visuals: propose 2–3 simple charts/tables and 1 calculator or checklist if the topic fits (don’t invent data).'
+  ]);
+
+  const trustBlock = listFromInput(trust_signals, [
+    'Author line with relevant credentials; last-updated date.',
+    'Cite neutral authorities (e.g., NAIC, state DMV pages) where needed; avoid brand bias.',
+    'Add a clear disclaimer: informational, not legal/financial advice.',
+    'Inclusive, plain language; explain jargon in the Glossary.'
+  ]);
+
+  const onPageBlock = listFromInput(on_page_requirements, [
+    'Use the exact H1, Title, and Meta provided.',
+    `Mention ${primary_kw} in the first 100 words and once in an H2/H3; keep density natural.`,
+    'Weave the secondary keywords where they fit contextually.',
+    'Add an actionable CTA at the end.',
+    'Accessibility: descriptive alt text for all images; clear link text (no “click here”).'
+  ]);
+
+  const uxBlock = listFromInput(ux_modules, [
+    'DefinitionSnippet (40–55 words) with the primary keyword verbatim in the first sentence',
+    'Scannable TL;DR box (bulleted list of 4–6 items)',
+    'Legal obligations & penalties matrix (high level)',
+    'Proof of financial responsibility explainer (SR-22 overview)',
+    'State-by-state requirement summary (grouped)',
+    'DMV appointment & documents checklist'
+  ]);
+
+  const internalBlock = listFromInput(internal_linking, [
+    'Link to the calculator page, the general car insurance hub, and related topics (full coverage, cost, registration, switching). Use descriptive anchors.'
+  ]);
+
+  const styleBlock = listFromInput(style_notes, [
+    'Clear, direct, and helpful. No hype, no fluff.',
+    'Use examples with realistic ranges; never fabricate sources.',
+    'Avoid repetitive phrasing and AI-ish templates. Vary sentence openings and keep rhythm human.'
+  ]);
+
+  return `You are a senior SEO content strategist for Finhabits. Write a blog that fully satisfies user intent and is AI-Overviews-ready.
+
+GOAL
+- Build the best resource on: “${topic}”
+- Primary keyword (use verbatim, keep original language): ${primary_kw}
+- Secondary keywords (use naturally, no stuffing): ${secondaryLine}
+- Intent: ${intentLine} Optimize for Featured Snippet (definition paragraph), People-Also-Ask, and rich results.
+
+MANDATORIES
+- H1 (visible on page): ${topic}
+- SEO Title (≤60 chars, keep as provided): ${seo_title}
+- Meta description (≤160 chars, keep as provided): ${meta_description}
+- URL to target: ${target_url}
+- Language: ${lang} for body copy; if the primary keyword is Spanish, include it verbatim in the H1 and in the first 100 words. Do not translate the primary keyword.
+- Word count: ${minWords}–${maxWords} words. Short paragraphs (2–3 sentences), meaningful subheads every 150–200 words.${notes}
+
+STRUCTURE & OUTLINE (use and adapt to the topic)
+${outlineBlock.map((item) => `- ${item}`).join('\n')}
+
+SERP STRATEGY
+${serpBlock.map((item) => `- ${item}`).join('\n')}
+
+TRUST & COMPLIANCE (E-E-A-T)
+${trustBlock.map((item) => `- ${item}`).join('\n')}
+
+ON-PAGE REQUIREMENTS
+${onPageBlock.map((item) => `- ${item}`).join('\n')}
+
+SCHEMA (JSON-LD)
+- Add FAQPage for FAQs, HowTo if there is a step-by-step, WebPage + BreadcrumbList + Organization.
+- Keep JSON-LD valid, minimal, and non-duplicative.
+
+UX MODULES TO INCLUDE
+${uxBlock.map((item) => `- ${item}`).join('\n')}
+
+INTERNAL LINKING (anchor suggestions)
+${internalBlock.map((item) => `- ${item}`).join('\n')}
+
+STYLE & TONE
+${styleBlock.map((item) => `- ${item}`).join('\n')}
+
+LEAD PARAGRAPH (write this now, 40–55 words, includes “${primary_kw}” once)
+>>>${leadSeed}
+
+Then continue with the full article following the outline above. Close with:
+- Author: ${authorLine}
+- Last updated: ${updatedLine}
+- Disclaimer: This content is for informational purposes only and does not constitute legal or financial advice. Always consult your state DMV or a licensed insurance professional.
+`;
+}
+
+app.post('/generate-article', async (req, res) => {
+  if (!openai) {
+    return res.status(500).json({ ok: false, error: 'Missing OPENAI_API_KEY in server env.' });
+  }
+
+  try {
+    const body = req.body || {};
+    const required = ['topic', 'primary_kw', 'seo_title', 'meta_description', 'target_url'];
+    const missing = required.filter((key) => !body[key]);
+    if (missing.length) {
+      return res.status(400).json({ ok: false, error: `Faltan campos obligatorios: ${missing.join(', ')}` });
+    }
+
+    const prompt = buildArticlePrompt(body);
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'You are an elite SEO content strategist who writes publication-ready articles for Finhabits.' },
+        { role: 'user', content: prompt }
+      ],
+      temperature: 0.3
+    });
+
+    const text = completion?.choices?.[0]?.message?.content || '';
+    res.json({ ok: true, article: text, prompt });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: String(err) });
   }
 });
 

--- a/finhabits-replit-proxy_v2/package-lock.json
+++ b/finhabits-replit-proxy_v2/package-lock.json
@@ -1,0 +1,1165 @@
+{
+  "name": "finhabits-replit-proxy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "finhabits-replit-proxy",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.19.2",
+        "node-fetch": "^3.3.2",
+        "openai": "^4.56.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.127",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
+      "integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/finhabits-replit-proxy_v2/package.json
+++ b/finhabits-replit-proxy_v2/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "express": "^4.19.2",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "openai": "^4.56.0"
   }
 }

--- a/finhabits-replit-proxy_v2/public/index.html
+++ b/finhabits-replit-proxy_v2/public/index.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html lang="es">
 <head>
@@ -9,113 +8,386 @@
 </head>
 <body>
   <div class="container">
-    <div class="header">
-      <div class="logo"></div>
+    <header class="header">
+      <div class="logo" aria-hidden="true"></div>
       <div class="brand">Finhabits</div>
       <div class="badge">Content Wizard</div>
-    </div>
+    </header>
 
-    <div class="card">
-      <div class="row"><div class="badge">Webhook:</div><code id="hook"></code></div>
-      <div class="helper">El token no se expone al navegador. Se usa proxy del servidor.</div>
-    </div>
-
-    <form id="form" class="card">
-      <div class="grid">
+    <section class="card status-card" aria-live="polite">
+      <div class="status-grid">
         <div>
-          <div class="label">Tema</div>
-          <input name="topic" placeholder="jubilación, seguros de auto..." required />
+          <div class="label">Webhook n8n</div>
+          <code id="hook">(cargando...)</code>
+          <p class="helper">El token se mantiene seguro en el servidor.</p>
         </div>
         <div>
-          <div class="label">Idioma</div>
-          <select name="language"><option>ES</option><option>EN</option></select>
+          <div class="label">OpenAI</div>
+          <div id="openai-status" class="pill pill-warn">Sin configurar</div>
+          <p class="helper">Configura <strong>OPENAI_API_KEY</strong> en Secrets para activar el framework.</p>
         </div>
       </div>
+    </section>
 
-      <div class="grid-3">
-        <div>
-          <div class="label">Tema central</div>
-          <select name="central_theme">
-            <option>Retiro</option><option>Seguros</option><option>Inversiones</option>
-            <option>Crédito</option><option>Ahorro</option><option>Impuestos</option>
-          </select>
-        </div>
-        <div>
-          <div class="label">KW primaria</div>
-          <input name="primary_kw" placeholder="ej. 401k para principiantes" />
-        </div>
-        <div>
-          <div class="label">KW secundarias (coma)</div>
-          <input name="secondary_kws" placeholder="aporte 401k, match, límites 2025" />
-        </div>
-      </div>
-
-      <div class="label" style="margin-top:12px">Descripción / objetivos</div>
-      <textarea name="description" placeholder="Qué se debe lograr, puntos a cubrir/evitar..."></textarea>
+    <form id="article-form" class="card form-card" novalidate>
+      <h2>Framework Finhabits – Artículo SEO</h2>
+      <p class="helper">Completa el formulario para generar un brief + artículo siguiendo la estructura aprobada para Finhabits.</p>
 
       <div class="grid">
-        <div>
-          <div class="label">Fuentes internas (slug, coma)</div>
-          <input name="internal_sources" placeholder="/aprende/401k, /aprende/ira" />
-        </div>
-        <div>
-          <div class="label">Fuentes externas (URLs, coma)</div>
-          <input name="external_sources" placeholder="https://www.irs.gov/..." />
-        </div>
+        <label class="field">
+          <span class="label">H1 / Tema principal</span>
+          <input name="topic" required value="Car insurance for vehicle registration: state-by-state requirements" />
+        </label>
+        <label class="field">
+          <span class="label">SEO Title</span>
+          <input name="seo_title" required value="Car insurance for vehicle registration: state-by-state requirements" />
+        </label>
       </div>
 
       <div class="grid">
-        <div>
-          <div class="label">Sugerir título (opcional)</div>
-          <input name="suggested_title" />
-        </div>
-        <div>
-          <div class="label">Slug sugerido (opcional)</div>
-          <input name="suggested_slug" />
-        </div>
+        <label class="field">
+          <span class="label">Meta description</span>
+          <input name="meta_description" required value="Learn which states require proof of insurance before registration." />
+        </label>
+        <label class="field">
+          <span class="label">URL objetivo</span>
+          <input name="target_url" required value="https://finhabits.com/insurance/auto/do-you-need-insurance-to-register-a-car/" />
+        </label>
       </div>
 
-      <label class="row" style="margin-top:12px">
-        <input type="checkbox" name="embed_video" />&nbsp;Insertar video al inicio (URL en descripción)
+      <div class="grid">
+        <label class="field">
+          <span class="label">Primary keyword</span>
+          <input name="primary_kw" required value="do you need insurance to register a car" />
+        </label>
+        <label class="field">
+          <span class="label">Secondary keywords (separadas por coma)</span>
+          <input name="secondary_kws" value="is car insurance required, do you have to have insurance to register a car" />
+        </label>
+      </div>
+
+      <div class="grid">
+        <label class="field">
+          <span class="label">Intent</span>
+          <input name="intent" value="Informational (education-first)." />
+        </label>
+        <label class="field">
+          <span class="label">Idioma (copia principal)</span>
+          <input name="language" value="US English" />
+        </label>
+      </div>
+
+      <div class="grid">
+        <label class="field">
+          <span class="label">Word count mínimo</span>
+          <input type="number" name="word_count_min" value="1400" />
+        </label>
+        <label class="field">
+          <span class="label">Word count máximo</span>
+          <input type="number" name="word_count_max" value="1900" />
+        </label>
+      </div>
+
+      <div class="grid">
+        <label class="field">
+          <span class="label">Autor</span>
+          <input name="author_name" value="Finhabits Team" />
+        </label>
+        <label class="field">
+          <span class="label">Credenciales del autor</span>
+          <input name="author_credentials" value="Senior SEO Content Strategist" />
+        </label>
+      </div>
+
+      <div class="grid">
+        <label class="field">
+          <span class="label">Última actualización</span>
+          <input name="last_updated" value="September 18, 2025" />
+        </label>
+        <label class="field">
+          <span class="label">Lead paragraph seed (opcional)</span>
+          <textarea name="lead_paragraph_seed" rows="3" placeholder="Si deseas fijar el primer párrafo de 40–55 palabras, escríbelo aquí."></textarea>
+        </label>
+      </div>
+
+      <label class="field">
+        <span class="label">Outline (1 sección por línea)</span>
+        <textarea name="outline_sections" rows="8">Intro with outcome-first promise + DefinitionSnippet
+What it is (precise definition with the primary keyword verbatim)
+Why it matters (benefits, risks, trade-offs)
+States that require proof of insurance
+Documents & DMV steps
+Common mistakes and how to avoid delays
+FAQs resolving People-Also-Ask queries
+Glossary (definitions of 6–10 terms)
+CTA + support options</textarea>
       </label>
 
-      <div class="row" style="justify-content:space-between;margin-top:16px">
-        <button id="send" type="submit">Enviar a n8n</button>
-        <div class="helper">Configura <b>N8N_WEBHOOK_URL</b> y <b>N8N_TOKEN</b> en Secrets.</div>
+      <label class="field">
+        <span class="label">SERP strategy (1 directiva por línea)</span>
+        <textarea name="serp_strategy" rows="6">DefinitionSnippet: a 40–55-word lead paragraph that defines the topic using “do you need insurance to register a car” verbatim once.
+PAA: add 5–7 FAQs with concise, direct answers (40–70 words each). Target questions users ask when comparing, buying or validating.
+Comparison blocks: use tables where relevant (e.g., inclusions vs exclusions, liability vs full coverage, state differences).
+Visuals: propose 2–3 simple charts/tables and 1 calculator or checklist if the topic fits (don’t invent data).</textarea>
+      </label>
+
+      <label class="field">
+        <span class="label">On-page requirements</span>
+        <textarea name="on_page_requirements" rows="5">Use the exact H1, Title, and Meta provided.
+Mention do you need insurance to register a car in the first 100 words and once in an H2/H3; keep density natural.
+Weave the secondary keywords where they fit contextually.
+Add an actionable CTA at the end (e.g., compare options, talk to a bilingual planner).
+Accessibility: descriptive alt text for all images; clear link text (no “click here”).</textarea>
+      </label>
+
+      <label class="field">
+        <span class="label">Trust & compliance (E-E-A-T)</span>
+        <textarea name="trust_signals" rows="4">Author line with relevant credentials; last-updated date.
+Cite neutral authorities (e.g., NAIC, state DMV pages) where needed; avoid brand bias.
+Add a clear disclaimer: informational, not legal/financial advice.
+Inclusive, plain language; explain jargon in the Glossary.</textarea>
+      </label>
+
+      <label class="field">
+        <span class="label">UX modules</span>
+        <textarea name="ux_modules" rows="6">DefinitionSnippet (40–55 words) with the primary keyword verbatim in the first sentence
+Scannable TL;DR box (bulleted list of 4–6 items)
+Legal obligations & penalties matrix (high level)
+Proof of financial responsibility explainer (SR-22 overview)
+State-by-state requirement summary (grouped)
+DMV appointment & documents checklist</textarea>
+      </label>
+
+      <label class="field">
+        <span class="label">Internal linking (anchors sugeridos)</span>
+        <textarea name="internal_linking" rows="4">Link to the calculator page, the general car insurance hub, and related topics (full coverage, cost, registration, switching). Use descriptive anchors (e.g., “compare full coverage vs liability”).</textarea>
+      </label>
+
+      <label class="field">
+        <span class="label">Style & tone</span>
+        <textarea name="style_notes" rows="4">Clear, direct, and helpful. No hype, no fluff. Use examples with realistic ranges; never fabricate sources.
+Avoid repetitive phrasing and AI-ish templates. Vary sentence openings and keep rhythm human.</textarea>
+      </label>
+
+      <label class="field">
+        <span class="label">Notas adicionales (guardrails específicos)</span>
+        <textarea name="additional_notes" rows="4" placeholder="Instrucciones extra, fuentes obligatorias, etc."></textarea>
+      </label>
+
+      <div class="form-actions">
+        <button id="generate" type="submit">Generar artículo</button>
+        <p class="helper">La respuesta incluye el artículo completo y el prompt usado.</p>
       </div>
     </form>
 
-    <div id="out" class="card" style="display:none"></div>
-    <div class="footer">© Finhabits</div>
+    <section id="article-output" class="card output-card" style="display:none">
+      <div class="output-head">
+        <h3>Artículo generado</h3>
+        <div class="row">
+          <button type="button" class="secondary" id="copy-article">Copiar artículo</button>
+          <button type="button" class="secondary" id="copy-prompt">Copiar prompt</button>
+        </div>
+      </div>
+      <div id="article-error" class="helper" role="alert" style="display:none"></div>
+      <pre id="article-text"></pre>
+      <details class="prompt-panel">
+        <summary>Ver prompt completo</summary>
+        <pre id="prompt-text"></pre>
+      </details>
+    </section>
+
+    <details class="card legacy-card">
+      <summary>Enviar intake a n8n (flujo original)</summary>
+      <p class="helper">Mantuvimos el formulario previo por si necesitas disparar el flujo en n8n.</p>
+      <form id="intake-form">
+        <div class="grid">
+          <label class="field">
+            <span class="label">Tema</span>
+            <input name="topic" placeholder="jubilación, seguros de auto..." required />
+          </label>
+          <label class="field">
+            <span class="label">Idioma</span>
+            <select name="language"><option>ES</option><option>EN</option></select>
+          </label>
+        </div>
+
+        <div class="grid-3">
+          <label class="field">
+            <span class="label">Tema central</span>
+            <select name="central_theme">
+              <option>Retiro</option><option>Seguros</option><option>Inversiones</option>
+              <option>Crédito</option><option>Ahorro</option><option>Impuestos</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="label">KW primaria</span>
+            <input name="primary_kw" placeholder="ej. 401k para principiantes" />
+          </label>
+          <label class="field">
+            <span class="label">KW secundarias (coma)</span>
+            <input name="secondary_kws" placeholder="aporte 401k, match, límites 2025" />
+          </label>
+        </div>
+
+        <label class="field">
+          <span class="label">Descripción / objetivos</span>
+          <textarea name="description" placeholder="Qué se debe lograr, puntos a cubrir/evitar..."></textarea>
+        </label>
+
+        <div class="grid">
+          <label class="field">
+            <span class="label">Fuentes internas (slug, coma)</span>
+            <input name="internal_sources" placeholder="/aprende/401k, /aprende/ira" />
+          </label>
+          <label class="field">
+            <span class="label">Fuentes externas (URLs, coma)</span>
+            <input name="external_sources" placeholder="https://www.irs.gov/..." />
+          </label>
+        </div>
+
+        <div class="grid">
+          <label class="field">
+            <span class="label">Sugerir título (opcional)</span>
+            <input name="suggested_title" />
+          </label>
+          <label class="field">
+            <span class="label">Slug sugerido (opcional)</span>
+            <input name="suggested_slug" />
+          </label>
+        </div>
+
+        <label class="row" style="margin-top:12px">
+          <input type="checkbox" name="embed_video" />
+          <span>Insertar video al inicio (URL en descripción)</span>
+        </label>
+
+        <div class="form-actions">
+          <button id="send" type="submit">Enviar a n8n</button>
+          <p class="helper">Configura <strong>N8N_WEBHOOK_URL</strong> y <strong>N8N_TOKEN</strong> en Secrets.</p>
+        </div>
+      </form>
+      <div id="intake-output" class="card" style="display:none"></div>
+    </details>
+
+    <footer class="footer">© Finhabits</footer>
   </div>
 
   <script>
-  const form = document.getElementById('form');
-  const out = document.getElementById('out');
+  const intakeForm = document.getElementById('intake-form');
+  const intakeOut = document.getElementById('intake-output');
   const hook = document.getElementById('hook');
-  fetch('/env').then(r=>r.json()).then(j=>{ hook.textContent = j.N8N_WEBHOOK_URL || '(no configurado)'; });
+  const openAiStatus = document.getElementById('openai-status');
 
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const btn = document.getElementById('send'); btn.disabled = true;
-    out.style.display = 'block'; out.innerHTML = '<div class="helper">Enviando…</div>';
-    const fd = new FormData(form); const payload = {};
-    for (const [k,v] of fd.entries()) {
-      if (k==='secondary_kws' || k==='internal_sources' || k==='external_sources'){
-        payload[k] = v.split(',').map(s=>s.trim()).filter(Boolean);
-      } else if (k==='embed_video'){
-        payload[k] = (fd.get('embed_video')==='on');
-      } else { payload[k]=v; }
+  fetch('/env').then(r => r.json()).then(j => {
+    hook.textContent = j.N8N_WEBHOOK_URL || '(no configurado)';
+    if (j.hasOpenAI) {
+      openAiStatus.textContent = 'Listo';
+      openAiStatus.classList.remove('pill-warn');
+      openAiStatus.classList.add('pill-ok');
     }
-    try{
-      const r = await fetch('/submit', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
-      const j = await r.json();
-      const cls = j.ok ? 'success' : 'error';
-      out.innerHTML = '<pre class="'+cls+'">'+JSON.stringify(j, null, 2)+'</pre>';
-    }catch(err){
-      out.innerHTML = '<pre class="error">'+String(err)+'</pre>';
-    }finally{ btn.disabled = false; }
   });
+
+  if (intakeForm) {
+    intakeForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const btn = document.getElementById('send');
+      btn.disabled = true;
+      intakeOut.style.display = 'block';
+      intakeOut.innerHTML = '<div class="helper">Enviando…</div>';
+      const fd = new FormData(intakeForm);
+      const payload = {};
+      for (const [k, v] of fd.entries()) {
+        if (k === 'secondary_kws' || k === 'internal_sources' || k === 'external_sources') {
+          payload[k] = v.split(',').map(s => s.trim()).filter(Boolean);
+        } else if (k === 'embed_video') {
+          payload[k] = fd.get('embed_video') === 'on';
+        } else {
+          payload[k] = v;
+        }
+      }
+      try {
+        const r = await fetch('/submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+        const j = await r.json();
+        const cls = j.ok ? 'success' : 'error';
+        intakeOut.innerHTML = '<pre class="' + cls + '">' + JSON.stringify(j, null, 2) + '</pre>';
+      } catch (err) {
+        intakeOut.innerHTML = '<pre class="error">' + String(err) + '</pre>';
+      } finally {
+        btn.disabled = false;
+      }
+    });
+  }
+
+  const articleForm = document.getElementById('article-form');
+  const articleOut = document.getElementById('article-output');
+  const articleText = document.getElementById('article-text');
+  const promptText = document.getElementById('prompt-text');
+  const articleError = document.getElementById('article-error');
+  const copyArticleBtn = document.getElementById('copy-article');
+  const copyPromptBtn = document.getElementById('copy-prompt');
+
+  const listFields = ['outline_sections', 'serp_strategy', 'trust_signals', 'on_page_requirements', 'ux_modules', 'internal_linking', 'style_notes'];
+
+  if (articleForm) {
+    articleForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const btn = document.getElementById('generate');
+      btn.disabled = true;
+      articleOut.style.display = 'block';
+      articleError.style.display = 'none';
+      articleText.textContent = 'Generando artículo…';
+      promptText.textContent = '';
+
+      const fd = new FormData(articleForm);
+      const payload = {};
+      for (const [k, v] of fd.entries()) {
+        if (k === 'secondary_kws') {
+          payload[k] = v.split(',').map(s => s.trim()).filter(Boolean);
+        } else if (listFields.includes(k)) {
+          payload[k] = v;
+        } else if (k === 'word_count_min' || k === 'word_count_max') {
+          const num = parseInt(v, 10);
+          if (!Number.isNaN(num)) payload[k] = num;
+        } else {
+          payload[k] = v;
+        }
+      }
+
+      try {
+        const r = await fetch('/generate-article', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+        const j = await r.json();
+        if (!j.ok) {
+          throw new Error(j.error || 'Error generando el artículo');
+        }
+        articleText.textContent = j.article || '';
+        promptText.textContent = j.prompt || '';
+      } catch (err) {
+        articleError.textContent = String(err);
+        articleError.style.display = 'block';
+        articleText.textContent = '';
+      } finally {
+        btn.disabled = false;
+      }
+    });
+  }
+
+  async function copyToClipboard(getText) {
+    try {
+      const text = getText();
+      if (!text) return;
+      await navigator.clipboard.writeText(text);
+      alert('Copiado al portapapeles.');
+    } catch (err) {
+      alert('No se pudo copiar: ' + err);
+    }
+  }
+
+  if (copyArticleBtn) {
+    copyArticleBtn.addEventListener('click', () => copyToClipboard(() => articleText.textContent));
+  }
+  if (copyPromptBtn) {
+    copyPromptBtn.addEventListener('click', () => copyToClipboard(() => promptText.textContent));
+  }
   </script>
 </body>
 </html>

--- a/finhabits-replit-proxy_v2/public/styles.css
+++ b/finhabits-replit-proxy_v2/public/styles.css
@@ -1,21 +1,45 @@
 
-:root { --brand:#FED172; --ink:#212121; --bg:#0B0B0B; --card:#171717; }
-*{box-sizing:border-box} body{margin:0;font-family:Inter,system-ui,Arial;background:var(--bg);color:#eee}
-.container{max-width:980px;margin:40px auto;padding:20px}
+:root { --brand:#FED172; --ink:#212121; --bg:#0B0B0B; --card:#171717; --border:#222; }
+*{box-sizing:border-box}
+body{margin:0;font-family:Inter,system-ui,Arial;background:var(--bg);color:#eee;line-height:1.5}
+.container{max-width:1020px;margin:40px auto;padding:0 20px 60px}
 .header{display:flex;align-items:center;gap:12px;margin-bottom:20px}
 .logo{width:36px;height:36px;border-radius:8px;background:var(--brand)}
 .brand{font-weight:700;font-size:20px;color:#111;background:var(--brand);padding:6px 10px;border-radius:8px}
-.card{background:var(--card);border:1px solid #222;border-radius:16px;padding:20px;margin-top:16px;box-shadow:0 10px 30px rgba(0,0,0,.35)}
-.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-.grid-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:16px}
-.label{font-size:12px;letter-spacing:.5px;color:#bbb;margin-bottom:6px}
-input,select,textarea{width:100%;padding:12px 14px;border-radius:12px;border:1px solid #333;background:#101010;color:#eee}
-textarea{min-height:120px}
-button{background:var(--brand);color:#111;border:0;padding:12px 16px;border-radius:12px;font-weight:700;cursor:pointer}
+.badge{background:#222;border:1px solid var(--border);color:#ccc;border-radius:999px;padding:6px 10px;font-size:12px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:24px;margin-top:20px;box-shadow:0 10px 30px rgba(0,0,0,.35)}
+.card h2{margin:0 0 12px;font-size:24px}
+.card h3{margin:0;font-size:18px}
+.status-card{padding-bottom:8px}
+.status-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px}
+.grid-3{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:16px}
+.field{display:flex;flex-direction:column;gap:6px}
+.label{font-size:12px;letter-spacing:.5px;color:#bbb;text-transform:uppercase}
+input,select,textarea{width:100%;padding:12px 14px;border-radius:12px;border:1px solid #333;background:#101010;color:#eee;font:inherit}
+textarea{min-height:120px;resize:vertical}
+input:focus,select:focus,textarea:focus{outline:2px solid var(--brand);outline-offset:2px}
+button{background:var(--brand);color:#111;border:0;padding:12px 16px;border-radius:12px;font-weight:700;cursor:pointer;transition:opacity .2s ease}
+button:hover:not(:disabled){opacity:.9}
 button:disabled{opacity:.5;cursor:not-allowed}
+.secondary{background:transparent;border:1px solid #444;color:#f3f3f3}
 .helper{color:#aaa;font-size:12px;margin-top:6px}
 .row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
-.badge{background:#222;border:1px solid #333;color:#ccc;border-radius:999px;padding:6px 10px;font-size:12px}
-.footer{opacity:.7;margin-top:20px;font-size:12px}
-pre{white-space:pre-wrap;background:#0f0f0f;border:1px solid #222;border-radius:12px;padding:12px;color:#ddd}
-.success{border:1px solid #2e7d32;background:#0f1a12} .error{border:1px solid #b71c1c;background:#1a0f0f}
+.pill{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;font-size:12px;font-weight:600}
+.pill-warn{background:rgba(255,193,7,.1);color:#ffda73;border:1px solid rgba(255,193,7,.35)}
+.pill-ok{background:rgba(76,175,80,.16);color:#80e27e;border:1px solid rgba(76,175,80,.35)}
+.form-actions{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-top:12px;flex-wrap:wrap}
+.output-card pre{white-space:pre-wrap;background:#0f0f0f;border:1px solid var(--border);border-radius:12px;padding:16px;color:#ddd;max-height:520px;overflow:auto}
+.prompt-panel{margin-top:20px}
+.prompt-panel summary{cursor:pointer;font-weight:600}
+.legacy-card summary{cursor:pointer;font-weight:600;font-size:16px}
+.legacy-card .card{margin-top:16px}
+.footer{opacity:.7;margin-top:30px;font-size:12px;text-align:center}
+.success{border:1px solid #2e7d32;background:#0f1a12}
+.error{border:1px solid #b71c1c;background:#1a0f0f}
+
+@media (max-width:720px){
+  .container{margin:24px auto;padding:0 16px 40px}
+  .card{padding:20px}
+  .card h2{font-size:20px}
+}


### PR DESCRIPTION
## Summary
- integrate OpenAI client on the server with a reusable Finhabits article prompt builder and a new `/generate-article` endpoint
- refresh the public UI with a guided SEO framework form, output viewer, status indicators, and keep the legacy n8n intake form
- update styles and documentation for the new workflow and document the OpenAI secret requirement

## Testing
- npm run start -- --help

------
https://chatgpt.com/codex/tasks/task_e_68d073fe6c74832b8be306f2f81aa663